### PR TITLE
fix: 🐛 change icon type from object to function as required

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ export interface PickerSelectProps {
     pickerProps?: CustomPickerProps;
     touchableDoneProps?: CustomTouchableDoneProps;
     touchableWrapperProps?: CustomTouchableWrapperProps;
-    Icon?: React.ReactNode;
+    Icon?: () => JSX.Element;
     InputAccessoryView?: React.ReactNode;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "react-native-picker-select",
-    "version": "8.0.4",
+    "name": "@threads/react-native-picker-select",
+    "version": "8.0.5",
     "description": "A Picker component for React Native which emulates the native <select> interfaces for each platform",
     "license": "MIT",
     "author": "Michael Lefkowitz <lefkowitz.michael@gmail.com>",


### PR DESCRIPTION
As exposed here (https://github.com/lawnstarter/react-native-picker-select/issues/488)
and here (https://github.com/lawnstarter/react-native-picker-select/issues/499)
we need to change the icon type as it's required to be a function