### PR TITLE
chore: update deprecated GitHub commands and bump Node 12 actions

### DIFF
--- a/.github/workflows/npmpublish.yml.bak
+++ b/.github/workflows/npmpublish.yml.bak
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -18,7 +18,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: 12


### PR DESCRIPTION
Part of [TBUY-1493](https://threadsstylingltd.atlassian.net/browse/TBUY-1493);	[Reference 1](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/),	[Reference 2](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/);
Replacing the explicit usage of the commands and bumping some Node 12 actions that use them as well.
Only bumping of Node version used in CI to .nvmrc if applicable and not defined in action/setup-node.

This was updated in bulk using [multi-gitter](https://github.com/lindell/multi-gitter), please double check for inconsistencies